### PR TITLE
Do not use scalameta in core project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,6 @@ lazy val coreJVM = coreM.jvm
 lazy val coreJS  = coreM.js
 lazy val coreM   = module("core", CrossType.Pure)
   .settings(addLibs(vAll, "cats-core"))
-  .settings(metaMacroSettings)
   .settings(simulacrumSettings(vAll))
   .enablePlugins(AutomateHeaderPlugin)
 


### PR DESCRIPTION
Hi,
I believe that using scalameta in core project is mistake as it brings many unnecessary dependencies such as google protobuf.